### PR TITLE
feat(issue-36): ワークシート編集とメンバー割り当て変更機能

### DIFF
--- a/app/controllers/api/v1/histories_controller.rb
+++ b/app/controllers/api/v1/histories_controller.rb
@@ -9,17 +9,18 @@ module Api
 
         @histories = if params[:year] && params[:month] && params[:day]
                        date = Date.new(params[:year].to_i, params[:month].to_i, params[:day].to_i)
-                       History.where(member_id: worksheet_member_ids).by_date(date).recent
+                       History.where(worksheet_id: worksheet.id, member_id: worksheet_member_ids).by_date(date).recent
                      elsif params[:year] && params[:month]
-                       History.where(member_id: worksheet_member_ids).by_month(params[:year], params[:month]).recent
+                       History.where(worksheet_id: worksheet.id, member_id: worksheet_member_ids).by_month(params[:year], params[:month]).recent
                      else
-                       History.where(member_id: worksheet_member_ids).recent
+                       History.where(worksheet_id: worksheet.id, member_id: worksheet_member_ids).recent
                      end
         render json: @histories, include: %i[work member]
       end
 
       def create
-        @history = History.new(history_params)
+        worksheet = current_worksheet_for_params
+        @history = History.new(history_params.merge(worksheet_id: worksheet.id))
         if @history.save
           render json: @history, status: :created
         else
@@ -28,12 +29,20 @@ module Api
       end
 
       def destroy
+        worksheet = current_worksheet_for_params
         @history = History.find(params[:id])
+
+        # worksheet_id が一致することを確認
+        unless @history.worksheet_id == worksheet.id
+          return render_error('このワークシートのHistoryではありません', :forbidden)
+        end
+
         @history.destroy!
         head :no_content
       end
 
       def bulk_create
+        worksheet = current_worksheet_for_params
         histories_data = Array(params[:histories])
 
         return render_error('履歴データが指定されていません', :unprocessable_content) if histories_data.empty?
@@ -44,7 +53,8 @@ module Api
             created_histories << History.create!(
               member_id: history_data[:member_id],
               work_id: history_data[:work_id],
-              date: history_data[:date]
+              date: history_data[:date],
+              worksheet_id: worksheet.id
             )
           end
         end

--- a/app/controllers/api/v1/works_controller.rb
+++ b/app/controllers/api/v1/works_controller.rb
@@ -130,7 +130,7 @@ module Api
 
         History.transaction do
           member_ids.each do |member_id|
-            History.find_or_create_by!(member_id: member_id, date: date) do |history|
+            History.find_or_create_by!(member_id: member_id, date: date, worksheet_id: current_worksheet.id) do |history|
               history.work_id = nil
             end
           end
@@ -163,7 +163,7 @@ module Api
       def remove_duplicate_assignments(date)
         # 指定日付のHistoryレコードをメンバーごとにグループ化
         worksheet_member_ids = current_worksheet.members.pluck(:id)
-        histories = History.where(date: date, member_id: worksheet_member_ids)
+        histories = History.where(date: date, member_id: worksheet_member_ids, worksheet_id: current_worksheet.id)
         grouped = histories.group_by(&:member_id)
 
         # 同じメンバーが複数回割り当てられている場合、最初の1つ以外を削除
@@ -204,7 +204,7 @@ module Api
 
       def shuffle_for_date(allocator)
         worksheet_member_ids = current_worksheet.members.pluck(:id)
-        histories = History.where(date: extract_target_date, member_id: worksheet_member_ids).includes(:member).to_a
+        histories = History.where(date: extract_target_date, member_id: worksheet_member_ids, worksheet_id: current_worksheet.id).includes(:member).to_a
         return render_error('参加メンバーがいません', :unprocessable_content) if histories.empty?
 
         works = load_shufflable_works(extract_target_date)

--- a/app/controllers/api/v1/worksheets_controller.rb
+++ b/app/controllers/api/v1/worksheets_controller.rb
@@ -61,11 +61,11 @@ module Api
 
       def assign_member
         deny_demo_user_modification! and return
-        worksheet = current_user.worksheets.find(params[:worksheet_id])
+        worksheet = current_user.worksheets.find(params[:id])
         member_id = params[:member_id]
         work_id = params[:work_id]
 
-        Rails.logger.info "Assigning member: worksheet=#{params[:worksheet_id]}, member=#{member_id}, work=#{work_id}"
+        Rails.logger.info "Assigning member: worksheet=#{params[:id]}, member=#{member_id}, work=#{work_id}"
 
         # メンバーとワークを検証
         member = worksheet.members.find_by(id: member_id)
@@ -81,9 +81,9 @@ module Api
         # 今日の日付を取得
         today = Date.today
 
-        # 既存の割り当てを確認（work_id = null のもののみ）
+        # 既存の割り当てを確認（work_id の値に関わらず検索）
         existing_history =
-          History.find_by(member_id:, date: today, work_id: nil, worksheet_id: worksheet.id)
+          History.find_by(member_id:, date: today, worksheet_id: worksheet.id)
 
         Rails.logger.info "Found existing history: #{existing_history.present?}"
 

--- a/app/controllers/api/v1/worksheets_controller.rb
+++ b/app/controllers/api/v1/worksheets_controller.rb
@@ -59,6 +59,50 @@ module Api
         render json: worksheets.map { |worksheet| serialize_worksheet(worksheet) }
       end
 
+      def assign_member
+        deny_demo_user_modification! and return
+        worksheet = current_user.worksheets.find(params[:worksheet_id])
+        member_id = params[:member_id]
+        work_id = params[:work_id]
+
+        # メンバーとワークを検証
+        member = worksheet.members.find_by(id: member_id)
+        work = worksheet.works.find_by(id: work_id)
+
+        unless member && work
+          render json: { error: 'メンバーまたはタスクが見つかりません' }, status: :not_found
+          return
+        end
+
+        # 今日の日付を取得
+        today = Date.today
+        year = today.year
+        month = today.month
+        day = today.day
+
+        # 既存の割り当てを確認
+        existing_history =
+          History.find_by(member_id:, year:, month:, day:)
+
+        if existing_history
+          # 既存の割り当てを更新
+          existing_history.update(work_id:)
+        else
+          # 新しい割り当てを作成
+          History.create(
+            member_id:,
+            work_id:,
+            year:,
+            month:,
+            day:
+          )
+        end
+
+        render json: { member_id:, work_id: }, status: :ok
+      rescue StandardError => e
+        render json: { error: e.message }, status: :internal_server_error
+      end
+
       private
 
       def worksheet_params

--- a/app/controllers/api/v1/worksheets_controller.rb
+++ b/app/controllers/api/v1/worksheets_controller.rb
@@ -65,9 +65,13 @@ module Api
         member_id = params[:member_id]
         work_id = params[:work_id]
 
+        Rails.logger.info "Assigning member: worksheet=#{params[:worksheet_id]}, member=#{member_id}, work=#{work_id}"
+
         # メンバーとワークを検証
         member = worksheet.members.find_by(id: member_id)
         work = worksheet.works.find_by(id: work_id)
+
+        Rails.logger.info "Found member: #{member.present?}, work: #{work.present?}"
 
         unless member && work
           render json: { error: 'メンバーまたはタスクが見つかりません' }, status: :not_found
@@ -80,16 +84,18 @@ module Api
         month = today.month
         day = today.day
 
-        # 既存の割り当てを確認
+        # 既存の割り当てを確認（work_id = null のもののみ）
         existing_history =
-          History.find_by(member_id:, year:, month:, day:)
+          History.find_by(member_id:, year:, month:, day:, work_id: nil)
+
+        Rails.logger.info "Found existing history: #{existing_history.present?}"
 
         if existing_history
           # 既存の割り当てを更新
-          existing_history.update(work_id:)
+          existing_history.update!(work_id:)
         else
           # 新しい割り当てを作成
-          History.create(
+          History.create!(
             member_id:,
             work_id:,
             year:,
@@ -100,6 +106,7 @@ module Api
 
         render json: { member_id:, work_id: }, status: :ok
       rescue StandardError => e
+        Rails.logger.error "Assignment error: #{e.message}"
         render json: { error: e.message }, status: :internal_server_error
       end
 

--- a/app/controllers/api/v1/worksheets_controller.rb
+++ b/app/controllers/api/v1/worksheets_controller.rb
@@ -80,13 +80,10 @@ module Api
 
         # 今日の日付を取得
         today = Date.today
-        year = today.year
-        month = today.month
-        day = today.day
 
         # 既存の割り当てを確認（work_id = null のもののみ）
         existing_history =
-          History.find_by(member_id:, year:, month:, day:, work_id: nil)
+          History.find_by(member_id:, date: today, work_id: nil, worksheet_id: worksheet.id)
 
         Rails.logger.info "Found existing history: #{existing_history.present?}"
 
@@ -98,9 +95,8 @@ module Api
           History.create!(
             member_id:,
             work_id:,
-            year:,
-            month:,
-            day:
+            date: today,
+            worksheet_id: worksheet.id
           )
         end
 

--- a/app/javascript/__tests__/components/AssignMemberModal.test.tsx
+++ b/app/javascript/__tests__/components/AssignMemberModal.test.tsx
@@ -242,4 +242,88 @@ describe('AssignMemberModal', () => {
       expect(mockOnClose).toHaveBeenCalled();
     });
   });
+
+  it('should handle unassigned member (currentWorkId = null)', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    mockAxios.post.mockResolvedValue({
+      data: { member_id: 1, work_id: 1 },
+    });
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        worksheetId={1}
+        currentWorkId={null}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />
+    );
+
+    // セレクトで未選択状態でタスクを選択
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveValue('');
+
+    await user.selectOptions(select, 'Work A');
+    expect(select).toHaveValue('1');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        `/api/v1/worksheets/1/assign_member`,
+        { member_id: mockMember.id, work_id: 1 },
+        expect.any(Object)
+      );
+      expect(mockOnSave).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should change assignment for already assigned member', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    mockAxios.post.mockResolvedValue({
+      data: { member_id: 1, work_id: 2 },
+    });
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />
+    );
+
+    // 初期状態は Work A が選択されている
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveValue('1');
+
+    // Work B に変更
+    await user.selectOptions(select, 'Work B');
+    expect(select).toHaveValue('2');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        `/api/v1/worksheets/1/assign_member`,
+        { member_id: mockMember.id, work_id: 2 },
+        expect.any(Object)
+      );
+      expect(mockOnSave).toHaveBeenCalled();
+    });
+  });
 });

--- a/app/javascript/__tests__/components/AssignMemberModal.test.tsx
+++ b/app/javascript/__tests__/components/AssignMemberModal.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import { AssignMemberModal } from '../../components/AssignMemberModal';
+import { setDefaultAxiosMocks } from '../spec/axiosMocks';
+
+vi.mock('axios');
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAxios = axios as any;
+
+describe('AssignMemberModal', () => {
+  const mockMember = {
+    id: 1,
+    name: 'John Doe',
+    kana: 'ジョンドウ',
+    archive: false,
+    worksheet_id: 1,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  };
+
+  const mockWorks = [
+    {
+      id: 1,
+      name: 'Work A',
+      multiple: false,
+      archive: false,
+      is_above: false,
+      worksheet_id: 1,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Work B',
+      multiple: false,
+      archive: false,
+      is_above: false,
+      worksheet_id: 1,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDefaultAxiosMocks();
+  });
+
+  it('should render modal with member name', () => {
+    const mockOnClose = vi.fn();
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+
+  it('should not render modal when isOpen is false', () => {
+    const mockOnClose = vi.fn();
+
+    render(
+      <AssignMemberModal
+        isOpen={false}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
+  });
+
+  it('should render work options in select dropdown', () => {
+    const mockOnClose = vi.fn();
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Work A')).toBeInTheDocument();
+    expect(screen.getByText('Work B')).toBeInTheDocument();
+  });
+
+  it('should update selected work when dropdown selection changes', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'Work B');
+
+    expect(select).toHaveValue('2');
+  });
+
+  it('should call onSave with member and selected work when save button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    mockAxios.post.mockResolvedValue({
+      data: { member_id: 1, work_id: 2 },
+    });
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'Work B');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        `/api/v1/worksheets/${mockMember.worksheet_id}/assign_member`,
+        { member_id: mockMember.id, work_id: 2 },
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('should call onClose when cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    const cancelButton = screen.getByRole('button', { name: /キャンセル/i });
+    await user.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should display error message when API call fails', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+
+    mockAxios.post.mockRejectedValue(new Error('API Error'));
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'Work B');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/エラーが発生しました/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should close modal and call onSave after successful assignment', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    mockAxios.post.mockResolvedValue({
+      data: { member_id: 1, work_id: 2 },
+    });
+
+    render(
+      <AssignMemberModal
+        isOpen={true}
+        member={mockMember}
+        works={mockWorks}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'Work B');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/javascript/__tests__/components/AssignMemberModal.test.tsx
+++ b/app/javascript/__tests__/components/AssignMemberModal.test.tsx
@@ -3,41 +3,39 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import { AssignMemberModal } from '../../components/AssignMemberModal';
-import { setDefaultAxiosMocks } from '../spec/axiosMocks';
+import { setDefaultAxiosMocks } from '../fixtures/axiosMocks';
+import type { Member, Work } from '../../types';
 
 vi.mock('axios');
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockAxios = axios as any;
 
 describe('AssignMemberModal', () => {
-  const mockMember = {
+  const mockMember: Member = {
     id: 1,
     name: 'John Doe',
     kana: 'ジョンドウ',
     archive: false,
-    worksheet_id: 1,
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
   };
 
-  const mockWorks = [
+  const mockWorks: Work[] = [
     {
       id: 1,
       name: 'Work A',
-      multiple: false,
+      multiple: 0,
       archive: false,
-      is_above: false,
-      worksheet_id: 1,
+      is_above: true,
       created_at: '2024-01-01T00:00:00Z',
       updated_at: '2024-01-01T00:00:00Z',
     },
     {
       id: 2,
       name: 'Work B',
-      multiple: false,
+      multiple: 0,
       archive: false,
-      is_above: false,
-      worksheet_id: 1,
+      is_above: true,
       created_at: '2024-01-01T00:00:00Z',
       updated_at: '2024-01-01T00:00:00Z',
     },
@@ -56,6 +54,8 @@ describe('AssignMemberModal', () => {
         isOpen={true}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={vi.fn()}
       />
@@ -72,6 +72,8 @@ describe('AssignMemberModal', () => {
         isOpen={false}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={vi.fn()}
       />
@@ -88,6 +90,8 @@ describe('AssignMemberModal', () => {
         isOpen={true}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={vi.fn()}
       />
@@ -106,6 +110,8 @@ describe('AssignMemberModal', () => {
         isOpen={true}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={vi.fn()}
       />
@@ -131,6 +137,8 @@ describe('AssignMemberModal', () => {
         isOpen={true}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={mockOnSave}
       />
@@ -144,7 +152,7 @@ describe('AssignMemberModal', () => {
 
     await waitFor(() => {
       expect(mockAxios.post).toHaveBeenCalledWith(
-        `/api/v1/worksheets/${mockMember.worksheet_id}/assign_member`,
+        `/api/v1/worksheets/1/assign_member`,
         { member_id: mockMember.id, work_id: 2 },
         expect.any(Object)
       );
@@ -160,6 +168,8 @@ describe('AssignMemberModal', () => {
         isOpen={true}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={vi.fn()}
       />
@@ -182,6 +192,8 @@ describe('AssignMemberModal', () => {
         isOpen={true}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={vi.fn()}
       />
@@ -212,6 +224,8 @@ describe('AssignMemberModal', () => {
         isOpen={true}
         member={mockMember}
         works={mockWorks}
+        worksheetId={1}
+        currentWorkId={1}
         onClose={mockOnClose}
         onSave={mockOnSave}
       />

--- a/app/javascript/__tests__/components/EditWorksheetModal.test.tsx
+++ b/app/javascript/__tests__/components/EditWorksheetModal.test.tsx
@@ -3,19 +3,20 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import { EditWorksheetModal } from '../../components/EditWorksheetModal';
-import { setDefaultAxiosMocks } from '../spec/axiosMocks';
+import { setDefaultAxiosMocks } from '../fixtures/axiosMocks';
+import type { WorksheetSummary } from '../../types';
 
 vi.mock('axios');
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockAxios = axios as any;
 
 describe('EditWorksheetModal', () => {
-  const mockWorksheet = {
+  const mockWorksheet: WorksheetSummary = {
     id: 1,
     name: 'Sample Worksheet',
-    user_id: 1,
-    created_at: '2024-01-01T00:00:00Z',
-    updated_at: '2024-01-01T00:00:00Z',
+    interval: 7,
+    week_use: false,
+    week: 0,
   };
 
   beforeEach(() => {

--- a/app/javascript/__tests__/components/EditWorksheetModal.test.tsx
+++ b/app/javascript/__tests__/components/EditWorksheetModal.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import { EditWorksheetModal } from '../../components/EditWorksheetModal';
+import { setDefaultAxiosMocks } from '../spec/axiosMocks';
+
+vi.mock('axios');
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAxios = axios as any;
+
+describe('EditWorksheetModal', () => {
+  const mockWorksheet = {
+    id: 1,
+    name: 'Sample Worksheet',
+    user_id: 1,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDefaultAxiosMocks();
+  });
+
+  it('should render modal with worksheet name', () => {
+    const mockOnClose = vi.fn();
+
+    render(
+      <EditWorksheetModal
+        isOpen={true}
+        worksheet={mockWorksheet}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Sample Worksheet')).toBeInTheDocument();
+  });
+
+  it('should not render modal when isOpen is false', () => {
+    const mockOnClose = vi.fn();
+
+    render(
+      <EditWorksheetModal
+        isOpen={false}
+        worksheet={mockWorksheet}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByDisplayValue('Sample Worksheet')).not.toBeInTheDocument();
+  });
+
+  it('should update input value when user types', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    render(
+      <EditWorksheetModal
+        isOpen={true}
+        worksheet={mockWorksheet}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />
+    );
+
+    const input = screen.getByDisplayValue('Sample Worksheet');
+    await user.clear(input);
+    await user.type(input, 'Updated Worksheet');
+
+    expect(input).toHaveValue('Updated Worksheet');
+  });
+
+  it('should call onSave with updated name when save button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    mockAxios.put.mockResolvedValue({
+      data: { ...mockWorksheet, name: 'Updated Worksheet' },
+    });
+
+    render(
+      <EditWorksheetModal
+        isOpen={true}
+        worksheet={mockWorksheet}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />
+    );
+
+    const input = screen.getByDisplayValue('Sample Worksheet');
+    await user.clear(input);
+    await user.type(input, 'Updated Worksheet');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        `/api/v1/worksheets/${mockWorksheet.id}`,
+        { worksheet: { name: 'Updated Worksheet' } },
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('should call onClose when cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+
+    render(
+      <EditWorksheetModal
+        isOpen={true}
+        worksheet={mockWorksheet}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    const cancelButton = screen.getByRole('button', { name: /キャンセル/i });
+    await user.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should display error message when API call fails', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+
+    mockAxios.put.mockRejectedValue(new Error('API Error'));
+
+    render(
+      <EditWorksheetModal
+        isOpen={true}
+        worksheet={mockWorksheet}
+        onClose={mockOnClose}
+        onSave={vi.fn()}
+      />
+    );
+
+    const input = screen.getByDisplayValue('Sample Worksheet');
+    await user.clear(input);
+    await user.type(input, 'Updated Worksheet');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/エラーが発生しました/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should close modal and call onClose after successful save', async () => {
+    const user = userEvent.setup();
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    mockAxios.put.mockResolvedValue({
+      data: { ...mockWorksheet, name: 'Updated Worksheet' },
+    });
+
+    render(
+      <EditWorksheetModal
+        isOpen={true}
+        worksheet={mockWorksheet}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+      />
+    );
+
+    const input = screen.getByDisplayValue('Sample Worksheet');
+    await user.clear(input);
+    await user.type(input, 'Updated Worksheet');
+
+    const saveButton = screen.getByRole('button', { name: /保存/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith({ ...mockWorksheet, name: 'Updated Worksheet' });
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/javascript/__tests__/components/Layout.test.tsx
+++ b/app/javascript/__tests__/components/Layout.test.tsx
@@ -39,6 +39,7 @@ describe('Layout - Issue #27: ワークシート選択機能の実装', () => {
     worksheets: mockWorksheets,
     activeWorksheetId: 1,
     onWorksheetSelect: vi.fn(),
+    onEditWorksheet: vi.fn(),
     showWorksheetModal: false,
     newWorksheetName: '',
     onShowWorksheetModal: vi.fn(),

--- a/app/javascript/components/App.tsx
+++ b/app/javascript/components/App.tsx
@@ -260,7 +260,13 @@ export default function App(): JSX.Element {
       <EditWorksheetModal
         isOpen={showEditWorksheetModal}
         worksheet={
-          editingWorksheet || { id: 0, name: '', user_id: 0, created_at: '', updated_at: '' }
+          editingWorksheet || {
+            id: 0,
+            name: '',
+            interval: 0,
+            week_use: false,
+            week: 0,
+          }
         }
         onClose={() => {
           setShowEditWorksheetModal(false);

--- a/app/javascript/components/App.tsx
+++ b/app/javascript/components/App.tsx
@@ -10,6 +10,7 @@ import Settings from './pages/Settings';
 import LandingPage from './auth/LandingPage';
 import AuthModal from './auth/AuthModal';
 import PasswordResetPage from './auth/PasswordResetPage';
+import { EditWorksheetModal } from './EditWorksheetModal';
 import type { AuthResponse, AuthUser, WorksheetSummary } from '../types';
 
 interface Notification {
@@ -40,6 +41,8 @@ export default function App(): JSX.Element {
   const [showWorksheetModal, setShowWorksheetModal] = useState<boolean>(false);
   const [newWorksheetName, setNewWorksheetName] = useState<string>('');
   const [worksheetNotification, setWorksheetNotification] = useState<Notification | null>(null);
+  const [editingWorksheet, setEditingWorksheet] = useState<WorksheetSummary | null>(null);
+  const [showEditWorksheetModal, setShowEditWorksheetModal] = useState<boolean>(false);
 
   useEffect(() => {
     axios
@@ -171,6 +174,39 @@ export default function App(): JSX.Element {
     }
   };
 
+  const handleEditWorksheet = async (updatedWorksheet: WorksheetSummary): Promise<void> => {
+    try {
+      setWorksheets(
+        worksheets.map((ws) => (ws.id === updatedWorksheet.id ? updatedWorksheet : ws))
+      );
+      setShowEditWorksheetModal(false);
+      setEditingWorksheet(null);
+      setWorksheetNotification({ message: 'ワークシートを更新しました', type: 'success' });
+      window.setTimeout(() => setWorksheetNotification(null), 4000);
+    } catch (error) {
+      const axiosError = error as { response?: { data?: { error?: string; errors?: string[] } } };
+      const msg =
+        axiosError.response?.data?.errors?.join(', ') ||
+        axiosError.response?.data?.error ||
+        'ワークシート更新に失敗しました';
+      setWorksheetNotification({ message: msg, type: 'error' });
+      window.setTimeout(() => setWorksheetNotification(null), 4000);
+    }
+  };
+
+  const handleOpenEditWorksheetModal = (worksheet: WorksheetSummary): void => {
+    if (isDemoUser()) {
+      setWorksheetNotification({
+        message: 'デモアカウントではワークシートを編集できません',
+        type: 'error',
+      });
+      window.setTimeout(() => setWorksheetNotification(null), 4000);
+      return;
+    }
+    setEditingWorksheet(worksheet);
+    setShowEditWorksheetModal(true);
+  };
+
   if (loading) {
     return <div className="flex items-center justify-center min-h-screen">読み込み中...</div>;
   }
@@ -221,12 +257,24 @@ export default function App(): JSX.Element {
 
   return (
     <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <EditWorksheetModal
+        isOpen={showEditWorksheetModal}
+        worksheet={
+          editingWorksheet || { id: 0, name: '', user_id: 0, created_at: '', updated_at: '' }
+        }
+        onClose={() => {
+          setShowEditWorksheetModal(false);
+          setEditingWorksheet(null);
+        }}
+        onSave={handleEditWorksheet}
+      />
       <Layout
         currentUserName={currentUser?.name || currentUser?.email || ''}
         onLogout={logout}
         worksheets={worksheets}
         activeWorksheetId={activeWorksheetId}
         onWorksheetSelect={handleWorksheetSelect}
+        onEditWorksheet={handleOpenEditWorksheetModal}
         showWorksheetModal={showWorksheetModal}
         newWorksheetName={newWorksheetName}
         onShowWorksheetModal={setShowWorksheetModal}

--- a/app/javascript/components/AssignMemberModal.tsx
+++ b/app/javascript/components/AssignMemberModal.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import type { Member, Work } from '../../types';
+
+interface AssignMemberModalProps {
+  isOpen: boolean;
+  member: Member;
+  works: Work[];
+  worksheetId: number;
+  currentWorkId: number | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+export function AssignMemberModal({
+  isOpen,
+  member,
+  works,
+  worksheetId,
+  currentWorkId,
+  onClose,
+  onSave,
+}: AssignMemberModalProps): JSX.Element | null {
+  const [selectedWorkId, setSelectedWorkId] = useState<number | null>(currentWorkId);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    setSelectedWorkId(currentWorkId);
+    setError(null);
+  }, [currentWorkId, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSave = async (): Promise<void> => {
+    if (selectedWorkId === null) {
+      setError('タスクを選択してください');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await axios.post(
+        `/api/v1/worksheets/${worksheetId}/assign_member`,
+        { member_id: member.id, work_id: selectedWorkId },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      onSave();
+      onClose();
+    } catch (err) {
+      const error = err as {
+        response?: { data?: { error?: string; errors?: string[] } };
+      };
+      const errorMsg =
+        error.response?.data?.error ||
+        error.response?.data?.errors?.join(', ') ||
+        'メンバー割り当ての変更に失敗しました';
+      setError(errorMsg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-bold text-gray-900">割り当て先を変更</h3>
+          <button
+            onClick={onClose}
+            aria-label="モーダルを閉じる"
+            className="text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            <XMarkIcon className="h-6 w-6" />
+          </button>
+        </div>
+
+        <div className="mb-4 p-3 bg-primary-50 border border-primary-300 rounded-lg">
+          <p className="text-sm text-primary-700 font-medium">{member.name}</p>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-300 rounded-lg">
+            <p className="text-sm text-red-700">エラーが発生しました</p>
+            <p className="text-xs text-red-600 mt-1">{error}</p>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <select
+            value={selectedWorkId ?? ''}
+            onChange={(e) =>
+              setSelectedWorkId(e.target.value ? parseInt(e.target.value, 10) : null)
+            }
+            className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+            disabled={isLoading}
+          >
+            <option value="">-- タスクを選択 --</option>
+            {works
+              .filter((work) => work.is_above)
+              .map((work) => (
+                <option key={work.id} value={work.id}>
+                  {work.name}
+                </option>
+              ))}
+          </select>
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoading}
+            >
+              キャンセル
+            </button>
+            <button
+              onClick={() => void handleSave()}
+              className="px-4 py-2 rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoading}
+            >
+              {isLoading ? '保存中...' : '保存'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/components/AssignMemberModal.tsx
+++ b/app/javascript/components/AssignMemberModal.tsx
@@ -45,7 +45,15 @@ export function AssignMemberModal({
     setError(null);
 
     try {
-      await axios.post(
+      // デバッグログ
+      console.log('Assigning member:', {
+        worksheetId,
+        memberId: member.id,
+        workId: selectedWorkId,
+        url: `/api/v1/worksheets/${worksheetId}/assign_member`,
+      });
+
+      const response = await axios.post(
         `/api/v1/worksheets/${worksheetId}/assign_member`,
         { member_id: member.id, work_id: selectedWorkId },
         {
@@ -54,9 +62,12 @@ export function AssignMemberModal({
           },
         }
       );
+
+      console.log('Assignment response:', response.data);
       onSave();
       onClose();
     } catch (err) {
+      console.error('Assignment error:', err);
       const error = err as {
         response?: { data?: { error?: string; errors?: string[] } };
       };

--- a/app/javascript/components/AssignMemberModal.tsx
+++ b/app/javascript/components/AssignMemberModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import type { Member, Work } from '../../types';
+import type { Member, Work } from '../types';
 
 interface AssignMemberModalProps {
   isOpen: boolean;

--- a/app/javascript/components/EditWorksheetModal.tsx
+++ b/app/javascript/components/EditWorksheetModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import type { WorksheetSummary } from '../../types';
+import type { WorksheetSummary } from '../types';
 
 interface EditWorksheetModalProps {
   isOpen: boolean;
@@ -16,12 +16,12 @@ export function EditWorksheetModal({
   onClose,
   onSave,
 }: EditWorksheetModalProps): JSX.Element | null {
-  const [worksheetName, setWorksheetName] = useState<string>(worksheet.name);
+  const [worksheetName, setWorksheetName] = useState<string>(worksheet.name || '');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
-    setWorksheetName(worksheet.name);
+    setWorksheetName(worksheet.name || '');
     setError(null);
   }, [worksheet, isOpen]);
 

--- a/app/javascript/components/EditWorksheetModal.tsx
+++ b/app/javascript/components/EditWorksheetModal.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import type { WorksheetSummary } from '../../types';
+
+interface EditWorksheetModalProps {
+  isOpen: boolean;
+  worksheet: WorksheetSummary;
+  onClose: () => void;
+  onSave: (worksheet: WorksheetSummary) => void;
+}
+
+export function EditWorksheetModal({
+  isOpen,
+  worksheet,
+  onClose,
+  onSave,
+}: EditWorksheetModalProps): JSX.Element | null {
+  const [worksheetName, setWorksheetName] = useState<string>(worksheet.name);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    setWorksheetName(worksheet.name);
+    setError(null);
+  }, [worksheet, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSave = async (): Promise<void> => {
+    if (!worksheetName.trim()) {
+      setError('ワークシート名を入力してください');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await axios.put<WorksheetSummary>(
+        `/api/v1/worksheets/${worksheet.id}`,
+        { worksheet: { name: worksheetName.trim() } },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      onSave(response.data);
+      onClose();
+    } catch (err) {
+      const error = err as { response?: { data?: { errors?: string[] } } };
+      const errorMsg =
+        error.response?.data?.errors?.join(', ') || 'ワークシート名の更新に失敗しました';
+      setError(errorMsg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-bold text-gray-900">ワークシート名を編集</h3>
+          <button
+            onClick={onClose}
+            aria-label="モーダルを閉じる"
+            className="text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            <XMarkIcon className="h-6 w-6" />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-300 rounded-lg">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <input
+            type="text"
+            value={worksheetName}
+            onChange={(e) => setWorksheetName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !isLoading) {
+                void handleSave();
+              }
+            }}
+            placeholder="ワークシート名"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+            autoFocus
+            disabled={isLoading}
+          />
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoading}
+            >
+              キャンセル
+            </button>
+            <button
+              onClick={() => void handleSave()}
+              className="px-4 py-2 rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoading}
+            >
+              {isLoading ? '保存中...' : '保存'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/components/Layout.tsx
+++ b/app/javascript/components/Layout.tsx
@@ -5,7 +5,6 @@ import {
   UserGroupIcon,
   ClipboardDocumentListIcon,
   CalendarIcon,
-  CogIcon,
   Bars3Icon,
   XMarkIcon,
   PlusIcon,
@@ -65,7 +64,6 @@ export default function Layout({
     { name: 'メンバー', href: '/members', icon: UserGroupIcon },
     { name: 'タスク', href: '/works', icon: ClipboardDocumentListIcon },
     { name: '履歴', href: '/history', icon: CalendarIcon },
-    { name: '設定', href: '/settings', icon: CogIcon },
   ];
 
   return (

--- a/app/javascript/components/Layout.tsx
+++ b/app/javascript/components/Layout.tsx
@@ -30,6 +30,7 @@ interface LayoutProps {
   worksheets: WorksheetSummary[];
   activeWorksheetId: number | null;
   onWorksheetSelect: (id: number) => void;
+  onEditWorksheet: (worksheet: WorksheetSummary) => void;
   showWorksheetModal: boolean;
   newWorksheetName: string;
   onShowWorksheetModal: (show: boolean) => void;
@@ -47,6 +48,7 @@ export default function Layout({
   worksheets,
   activeWorksheetId,
   onWorksheetSelect,
+  onEditWorksheet,
   showWorksheetModal,
   newWorksheetName,
   onShowWorksheetModal,
@@ -197,11 +199,13 @@ export default function Layout({
                   key={worksheet.id}
                   role="tab"
                   onClick={() => onWorksheetSelect(worksheet.id)}
+                  onDoubleClick={() => onEditWorksheet(worksheet)}
                   className={`px-4 py-2 rounded-lg whitespace-nowrap transition-colors ${
                     activeWorksheetId === worksheet.id
-                      ? 'bg-primary-600 text-white border border-primary-600'
+                      ? 'bg-primary-600 text-white border border-primary-600 hover:bg-primary-700'
                       : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
                   }`}
+                  title="ダブルクリックで編集"
                 >
                   {worksheet.name}
                 </button>

--- a/app/javascript/components/Layout.tsx
+++ b/app/javascript/components/Layout.tsx
@@ -209,7 +209,9 @@ export default function Layout({
                         ? 'bg-primary-600 text-white border border-primary-600 hover:bg-primary-700'
                         : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
                     }`}
-                    title={activeWorksheetId === worksheet.id ? 'クリックで編集' : 'クリックで切り替え'}
+                    title={
+                      activeWorksheetId === worksheet.id ? 'クリックで編集' : 'クリックで切り替え'
+                    }
                   >
                     {worksheet.name}
                   </button>

--- a/app/javascript/components/Layout.tsx
+++ b/app/javascript/components/Layout.tsx
@@ -195,20 +195,25 @@ export default function Layout({
             {/* Worksheet Tabs */}
             <div className="flex items-center gap-2 overflow-x-auto">
               {worksheets.map((worksheet: WorksheetSummary) => (
-                <button
-                  key={worksheet.id}
-                  role="tab"
-                  onClick={() => onWorksheetSelect(worksheet.id)}
-                  onDoubleClick={() => onEditWorksheet(worksheet)}
-                  className={`px-4 py-2 rounded-lg whitespace-nowrap transition-colors ${
-                    activeWorksheetId === worksheet.id
-                      ? 'bg-primary-600 text-white border border-primary-600 hover:bg-primary-700'
-                      : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
-                  }`}
-                  title="ダブルクリックで編集"
-                >
-                  {worksheet.name}
-                </button>
+                <div key={worksheet.id} className="relative">
+                  <button
+                    key={`${worksheet.id}-select`}
+                    role="tab"
+                    onClick={() =>
+                      activeWorksheetId === worksheet.id
+                        ? onEditWorksheet(worksheet)
+                        : onWorksheetSelect(worksheet.id)
+                    }
+                    className={`px-4 py-2 rounded-lg whitespace-nowrap transition-colors ${
+                      activeWorksheetId === worksheet.id
+                        ? 'bg-primary-600 text-white border border-primary-600 hover:bg-primary-700'
+                        : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
+                    }`}
+                    title={activeWorksheetId === worksheet.id ? 'クリックで編集' : 'クリックで切り替え'}
+                  >
+                    {worksheet.name}
+                  </button>
+                </div>
               ))}
               <button
                 onClick={() =>

--- a/app/javascript/components/auth/LandingPage.tsx
+++ b/app/javascript/components/auth/LandingPage.tsx
@@ -25,7 +25,7 @@ export default function LandingPage({
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-teal-50 px-4 py-10">
       <div className="mx-auto max-w-4xl">
         <h1 className="mb-2 text-4xl font-black text-slate-900">TaskWheel</h1>
-        <p className="mb-8 text-slate-700">チームのタスク管理をシンプルにするアプリ</p>
+        <p className="mb-8 text-slate-700">タスクの割り当てを楽に管理にするアプリ</p>
 
         <div className="mb-8 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
           <h2 className="mb-4 text-xl font-bold text-slate-900">はじめる</h2>

--- a/app/javascript/components/pages/Dashboard.tsx
+++ b/app/javascript/components/pages/Dashboard.tsx
@@ -188,21 +188,11 @@ export default function Dashboard({ worksheetId, _isDemoUser = false }: Props): 
     }
   };
 
-  const handleDeleteMember = async (historyId: number): Promise<void> => {
-    if (!window.confirm('この割り当てを削除しますか？')) return;
-    try {
-      await axios.delete(`/api/v1/histories/${historyId}`);
-      fetchData();
-    } catch {
-      showNotification('削除に失敗しました', 'error');
-    }
-  };
-
-  const handleOpenAssignMemberModal = (memberName: string, workId: number): void => {
+  const handleOpenAssignMemberModal = (memberName: string, workId: number | null): void => {
     const member = members.find((m) => m.name === memberName);
     if (member) {
       setSelectedMemberForAssignment(member);
-      setCurrentAssignmentWorkId(workId);
+      setCurrentAssignmentWorkId(workId ?? null);
       setShowAssignMemberModal(true);
     }
   };
@@ -885,7 +875,9 @@ export default function Dashboard({ worksheetId, _isDemoUser = false }: Props): 
                       {unassignedMembers.map((member) => (
                         <div
                           key={member.id}
-                          className="p-4 bg-white border-2 border-yellow-300 rounded-lg hover:shadow-md transition-all flex items-center justify-center"
+                          onClick={() => handleOpenAssignMemberModal(member.name, null)}
+                          className="p-4 bg-white border-2 border-yellow-300 rounded-lg hover:bg-yellow-50 hover:border-yellow-500 cursor-pointer transition-all flex items-center justify-center"
+                          title="クリックで割り当て先を変更"
                         >
                           <p className="font-semibold text-gray-900 text-center">{member.name}</p>
                         </div>

--- a/app/javascript/components/pages/Dashboard.tsx
+++ b/app/javascript/components/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import {
   SparklesIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
+import { AssignMemberModal } from '../AssignMemberModal';
 import type { Member, Work, History } from '../../types';
 
 interface Notification {
@@ -37,6 +38,11 @@ export default function Dashboard({ worksheetId, _isDemoUser = false }: Props): 
   const [showCalendar, setShowCalendar] = useState<boolean>(false);
   const [notification, setNotification] = useState<Notification | null>(null);
   const [isScrolled, setIsScrolled] = useState<boolean>(false);
+  const [selectedMemberForAssignment, setSelectedMemberForAssignment] = useState<Member | null>(
+    null
+  );
+  const [currentAssignmentWorkId, setCurrentAssignmentWorkId] = useState<number | null>(null);
+  const [showAssignMemberModal, setShowAssignMemberModal] = useState<boolean>(false);
 
   const showNotification = useCallback((message: string, type: 'success' | 'error' = 'success') => {
     setNotification({ message, type });
@@ -190,6 +196,22 @@ export default function Dashboard({ worksheetId, _isDemoUser = false }: Props): 
     } catch {
       showNotification('削除に失敗しました', 'error');
     }
+  };
+
+  const handleOpenAssignMemberModal = (memberName: string, workId: number): void => {
+    const member = members.find((m) => m.name === memberName);
+    if (member) {
+      setSelectedMemberForAssignment(member);
+      setCurrentAssignmentWorkId(workId);
+      setShowAssignMemberModal(true);
+    }
+  };
+
+  const handleSaveAssignment = async (): Promise<void> => {
+    fetchData();
+    setShowAssignMemberModal(false);
+    setSelectedMemberForAssignment(null);
+    setCurrentAssignmentWorkId(null);
   };
 
   const getTodayAssignedMembers = (workId: number): History[] => {
@@ -451,6 +473,23 @@ export default function Dashboard({ worksheetId, _isDemoUser = false }: Props): 
 
   return (
     <div className="space-y-6">
+      {/* AssignMemberModal */}
+      {worksheetId && selectedMemberForAssignment && (
+        <AssignMemberModal
+          isOpen={showAssignMemberModal}
+          member={selectedMemberForAssignment}
+          works={works}
+          worksheetId={worksheetId}
+          currentWorkId={currentAssignmentWorkId}
+          onClose={() => {
+            setShowAssignMemberModal(false);
+            setSelectedMemberForAssignment(null);
+            setCurrentAssignmentWorkId(null);
+          }}
+          onSave={handleSaveAssignment}
+        />
+      )}
+
       {/* Notification Popup */}
       {notification && (
         <div className="fixed top-6 right-6 z-50 max-w-sm w-full animate-fade-in">
@@ -912,8 +951,11 @@ export default function Dashboard({ worksheetId, _isDemoUser = false }: Props): 
                           {todayAssignments.map((assignment) => (
                             <div
                               key={assignment.id}
-                              onClick={() => handleDeleteMember(assignment.id)}
-                              className="p-4 bg-white border-2 border-primary-300 rounded-lg hover:bg-red-50 hover:border-red-400 cursor-pointer transition-all flex items-center justify-center"
+                              onClick={() =>
+                                handleOpenAssignMemberModal(assignment.member?.name || '', work.id)
+                              }
+                              className="p-4 bg-white border-2 border-primary-300 rounded-lg hover:bg-primary-50 hover:border-primary-500 cursor-pointer transition-all flex items-center justify-center"
+                              title="クリックで割り当て先を変更"
                             >
                               <p className="font-semibold text-gray-900 text-center">
                                 {assignment.member?.name}

--- a/app/javascript/components/pages/Members.tsx
+++ b/app/javascript/components/pages/Members.tsx
@@ -167,6 +167,36 @@ export default function Members({ worksheetId, isDemoUser = false }: Props): JSX
   });
   const [showImportModal, setShowImportModal] = useState<boolean>(false);
 
+  const handleDemoUserAction = (actionName: string): void => {
+    if (isDemoUser) {
+      alert(`デモアカウントではメンバーを${actionName}できません`);
+      return;
+    }
+  };
+
+  const handleBulkFormToggle = (): void => {
+    handleDemoUserAction('追加');
+    if (!isDemoUser) {
+      setShowBulkForm(!showBulkForm);
+      setShowSingleForm(false);
+    }
+  };
+
+  const handleSingleFormToggle = (): void => {
+    handleDemoUserAction('追加');
+    if (!isDemoUser) {
+      setShowSingleForm(!showSingleForm);
+      setShowBulkForm(false);
+    }
+  };
+
+  const handleImportModalOpen = (): void => {
+    handleDemoUserAction('インポート');
+    if (!isDemoUser) {
+      setShowImportModal(true);
+    }
+  };
+
   useEffect(() => {
     void fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -347,38 +377,24 @@ export default function Members({ worksheetId, isDemoUser = false }: Props): JSX
             <option value="archived">アーカイブ</option>
           </select>
           <button
-            onClick={() => {
-              setShowBulkForm(!showBulkForm);
-              setShowSingleForm(false);
-            }}
+            onClick={handleBulkFormToggle}
             className="btn-primary py-1 whitespace-nowrap"
-            disabled={isDemoUser}
-            title={isDemoUser ? 'デモアカウントでは使用できません' : ''}
+            title="一括追加"
           >
             {showBulkForm ? 'キャンセル' : '一括追加'}
           </button>
           <button
-            onClick={() => {
-              setShowSingleForm(!showSingleForm);
-              setShowBulkForm(false);
-            }}
+            onClick={handleSingleFormToggle}
             className="btn-primary py-1 whitespace-nowrap"
-            disabled={isDemoUser}
-            title={isDemoUser ? 'デモアカウントでは使用できません' : ''}
+            title="新規登録"
           >
             {showSingleForm ? 'キャンセル' : '新規登録'}
           </button>
           <button
-            onClick={() => setShowImportModal(true)}
+            onClick={handleImportModalOpen}
             className="btn-secondary py-1 whitespace-nowrap"
-            disabled={isDemoUser || members.length === 0}
-            title={
-              isDemoUser
-                ? 'デモアカウントでは使用できません'
-                : members.length === 0
-                  ? 'インポート対象がありません'
-                  : ''
-            }
+            disabled={members.length === 0}
+            title={members.length === 0 ? 'インポート対象がありません' : 'インポート'}
           >
             インポート
           </button>

--- a/app/javascript/components/pages/Works.tsx
+++ b/app/javascript/components/pages/Works.tsx
@@ -50,6 +50,35 @@ export default function Works({ worksheetId, isDemoUser = false }: Props): JSX.E
     status: '0',
   });
   const [showImportModal, setShowImportModal] = useState<boolean>(false);
+  const handleDemoUserAction = (actionName: string): void => {
+    if (isDemoUser) {
+      alert(`デモアカウントではタスクを${actionName}できません`);
+      return;
+    }
+  };
+
+  const handleBulkFormToggle = (): void => {
+    handleDemoUserAction('追加');
+    if (!isDemoUser) {
+      setShowBulkForm(!showBulkForm);
+      setShowSingleForm(false);
+    }
+  };
+
+  const handleSingleFormToggle = (): void => {
+    handleDemoUserAction('追加');
+    if (!isDemoUser) {
+      setShowSingleForm(!showSingleForm);
+      setShowBulkForm(false);
+    }
+  };
+
+  const handleImportModalOpen = (): void => {
+    handleDemoUserAction('インポート');
+    if (!isDemoUser) {
+      setShowImportModal(true);
+    }
+  };
 
   useEffect(() => {
     void fetchData();
@@ -215,38 +244,24 @@ export default function Works({ worksheetId, isDemoUser = false }: Props): JSX.E
             <option value="archived">アーカイブ</option>
           </select>
           <button
-            onClick={() => {
-              setShowBulkForm(!showBulkForm);
-              setShowSingleForm(false);
-            }}
+            onClick={handleBulkFormToggle}
             className="btn-primary py-1 whitespace-nowrap"
-            disabled={isDemoUser}
-            title={isDemoUser ? 'デモアカウントでは本機能は使用できません' : ''}
+            title="一括追加"
           >
             {showBulkForm ? 'キャンセル' : '一括追加'}
           </button>
           <button
-            onClick={() => {
-              setShowSingleForm(!showSingleForm);
-              setShowBulkForm(false);
-            }}
+            onClick={handleSingleFormToggle}
             className="btn-primary py-1 whitespace-nowrap"
-            disabled={isDemoUser}
-            title={isDemoUser ? 'デモアカウントでは本機能は使用できません' : ''}
+            title="新規登録"
           >
             {showSingleForm ? 'キャンセル' : '新規登録'}
           </button>
           <button
-            onClick={() => setShowImportModal(true)}
+            onClick={handleImportModalOpen}
             className="btn-secondary py-1 whitespace-nowrap"
-            disabled={isDemoUser || works.length === 0}
-            title={
-              isDemoUser
-                ? 'デモアカウントでは使用できません'
-                : works.length === 0
-                  ? 'インポート対象がありません'
-                  : ''
-            }
+            disabled={works.length === 0}
+            title={works.length === 0 ? 'インポート対象がありません' : 'インポート'}
           >
             インポート
           </button>

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -3,9 +3,11 @@
 class History < ApplicationRecord
   belongs_to :work, optional: true
   belongs_to :member
+  belongs_to :worksheet
 
   validates :date, presence: true
-  validates :member_id, uniqueness: { scope: :date }
+  validates :worksheet_id, presence: true
+  validates :member_id, uniqueness: { scope: [:worksheet_id, :date] }
 
   scope :by_date, ->(date) { where(date: date) }
   scope :by_month, lambda { |year, month|

--- a/app/models/worksheet.rb
+++ b/app/models/worksheet.rb
@@ -4,6 +4,7 @@ class Worksheet < ApplicationRecord
   belongs_to :user
   has_many :members, dependent: :destroy
   has_many :works, dependent: :destroy
+  has_many :histories, dependent: :destroy
 
   before_validation :assign_test_fallback_user, on: :create
 

--- a/app/services/fair_shuffle_allocator.rb
+++ b/app/services/fair_shuffle_allocator.rb
@@ -23,7 +23,7 @@ class FairShuffleAllocator
     candidate_members = candidate_members.where(id: fixed_member_ids) if fixed_member_ids.any?
     candidate_members = candidate_members.where.not(id: excluded_member_ids) if excluded_member_ids.any?
 
-    today_assigned_counts = History.where(date: @date).where.not(work_id: nil).group(:member_id).count
+    today_assigned_counts = History.where(date: @date, worksheet_id: @worksheet.id).where.not(work_id: nil).group(:member_id).count
 
     scored_candidates = build_single_work_candidates(
       candidate_members: candidate_members,
@@ -46,7 +46,7 @@ class FairShuffleAllocator
     best_score = scored_candidates.min_by(&:last).last
     selected_member = scored_candidates.select { |_, score| score == best_score }.map(&:first).first
 
-    history = History.find_or_initialize_by(member_id: selected_member.id, date: @date)
+    history = History.find_or_initialize_by(member_id: selected_member.id, date: @date, worksheet_id: @worksheet.id)
     history.work_id = work.id
     history.save!
 
@@ -54,7 +54,7 @@ class FairShuffleAllocator
   end
 
   def shuffle_for_date(member_ids: nil)
-    histories = History.where(date: @date)
+    histories = History.where(date: @date, worksheet_id: @worksheet.id)
     histories = histories.where(member_id: member_ids) if member_ids.present?
     histories = histories.order(:id).to_a
     raise ActiveRecord::RecordInvalid, History.new if histories.empty?
@@ -133,7 +133,7 @@ class FairShuffleAllocator
       start_date = latest_reset_date if latest_reset_date.present?
     end
 
-    History.where(date: start_date..@date)
+    History.where(date: start_date..@date, worksheet_id: @worksheet.id)
            .where.not(work_id: nil)
            .distinct
            .pluck(:member_id, :work_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,9 @@ Rails.application.routes.draw do
           post :set_current
           get :importable
         end
+        member do
+          post :assign_member
+        end
       end
 
       # Dashboard

--- a/db/migrate/20260410000001_add_worksheet_id_to_histories.rb
+++ b/db/migrate/20260410000001_add_worksheet_id_to_histories.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class AddWorksheetIdToHistories < ActiveRecord::Migration[7.1]
+  def change
+    # 新しい worksheet_id カラムを追加（外部キー制約付き）
+    add_column :histories, :worksheet_id, :bigint, null: true
+
+    # 既存データを移行: work_id のワークシート ID を使用
+    reversible do |dir|
+      dir.up do
+        # work_id が存在するレコードに対して、関連ワークのワークシート ID を設定
+        execute(<<-SQL)
+          UPDATE histories
+          SET worksheet_id = works.worksheet_id
+          FROM works
+          WHERE histories.work_id = works.id AND histories.work_id IS NOT NULL
+        SQL
+
+        # work_id が null のレコード（参加状態のみ）に対しても worksheet_id を設定する必要があります
+        # ここでは一時的に最初のワークシート ID を使用
+        execute(<<-SQL)
+          UPDATE histories
+          SET worksheet_id = COALESCE(
+            (SELECT worksheet_id FROM members WHERE members.id = histories.member_id LIMIT 1),
+            (SELECT id FROM worksheets LIMIT 1)
+          )
+          WHERE worksheet_id IS NULL
+        SQL
+      end
+    end
+
+    # NOT NULL 制約を追加
+    change_column_null :histories, :worksheet_id, false
+
+    # 外部キー制約を追加
+    add_foreign_key :histories, :worksheets, column: :worksheet_id
+
+    # インデックスを追加（クエリ効率化用）
+    add_index :histories, :worksheet_id
+    add_index :histories, [:worksheet_id, :date]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_09_000001) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_10_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,10 +20,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_09_000001) do
     t.date "date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "worksheet_id", null: false
     t.index ["date"], name: "index_histories_on_date"
     t.index ["member_id", "date"], name: "index_histories_on_member_id_and_date"
     t.index ["member_id"], name: "index_histories_on_member_id"
     t.index ["work_id"], name: "index_histories_on_work_id"
+    t.index ["worksheet_id", "date"], name: "index_histories_on_worksheet_id_and_date"
+    t.index ["worksheet_id"], name: "index_histories_on_worksheet_id"
   end
 
   create_table "member_options", force: :cascade do |t|
@@ -106,6 +109,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_09_000001) do
   end
 
   add_foreign_key "histories", "members"
+  add_foreign_key "histories", "worksheets"
   add_foreign_key "member_options", "members"
   add_foreign_key "member_options", "works"
   add_foreign_key "members", "worksheets"

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
     member { association :member, worksheet: worksheet }
     work { association :work, worksheet: worksheet }
+    worksheet_id { worksheet.id }
     date { Date.current }
 
     trait :past do

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :history do
     transient do
-      worksheet { create(:worksheet) }
+      worksheet { nil }
     end
 
-    member { association :member, worksheet: worksheet }
-    work { association :work, worksheet: worksheet }
-    worksheet_id { worksheet.id }
+    member { association :member, worksheet: (worksheet || Worksheet.order(:id).first || association(:worksheet)) }
+    work { association :work, worksheet: member.worksheet }
+    worksheet_id { member.worksheet_id }
     date { Date.current }
 
     trait :past do

--- a/spec/requests/api_v1_worksheet_assign_member_spec.rb
+++ b/spec/requests/api_v1_worksheet_assign_member_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Api::V1::Worksheets - Assign Member', type: :request do
+  let(:user) { create(:user, email: 'assign-test@example.com', password: 'password123', password_confirmation: 'password123') }
+  let!(:worksheet) { create(:worksheet, user:) }
+  let!(:member) { create(:member, worksheet:) }
+  let!(:work1) { create(:work, worksheet:) }
+  let!(:work2) { create(:work, worksheet:) }
+  let(:today) { Date.today }
+
+  before do
+    post '/api/v1/auth/login', params: {
+      email: user.email,
+      password: 'password123'
+    }
+  end
+
+  describe 'POST /api/v1/worksheets/:id/assign_member' do
+    context 'when assigning an unassigned member to a work' do
+      it 'creates a new history record' do
+        expect {
+          post "/api/v1/worksheets/#{worksheet.id}/assign_member", params: {
+            member_id: member.id,
+            work_id: work1.id,
+          }
+        }.to change(History, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns member_id and work_id in response' do
+        post "/api/v1/worksheets/#{worksheet.id}/assign_member", params: {
+          member_id: member.id,
+          work_id: work1.id,
+        }
+
+        json = JSON.parse(response.body)
+        expect(json['member_id'].to_i).to eq(member.id)
+        expect(json['work_id'].to_i).to eq(work1.id)
+      end
+    end
+
+    context 'when changing assignment of an already assigned member' do
+      let!(:existing_history) do
+        create(:history, member:, work: work1, date: today, worksheet:)
+      end
+
+      it 'updates the existing history record without creating a new one' do
+        expect {
+          post "/api/v1/worksheets/#{worksheet.id}/assign_member", params: {
+            member_id: member.id,
+            work_id: work2.id,
+          }
+        }.not_to change(History, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(existing_history.reload.work_id).to eq(work2.id)
+      end
+    end
+
+    context 'when member_id is not found' do
+      it 'returns not found error' do
+        post "/api/v1/worksheets/#{worksheet.id}/assign_member", params: {
+          member_id: 99_999,
+          work_id: work1.id,
+        }
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)['error']).to include('見つかりません')
+      end
+    end
+
+    context 'when work_id is not found' do
+      it 'returns not found error' do
+        post "/api/v1/worksheets/#{worksheet.id}/assign_member", params: {
+          member_id: member.id,
+          work_id: 99_999,
+        }
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)['error']).to include('見つかりません')
+      end
+    end
+
+    context 'when user is demo account' do
+      before do
+        post '/api/v1/auth/login', params: {
+          email: 'test@example.com',
+          password: 'password123'
+        }
+      end
+
+      it 'returns forbidden error' do
+        demo_user = User.find_by(email: 'test@example.com') || create(:user, email: 'test@example.com', password: 'password123', password_confirmation: 'password123')
+        demo_worksheet = create(:worksheet, user: demo_user)
+        demo_member = create(:member, worksheet: demo_worksheet)
+        demo_work = create(:work, worksheet: demo_worksheet)
+
+        post "/api/v1/worksheets/#{demo_worksheet.id}/assign_member", params: {
+          member_id: demo_member.id,
+          work_id: demo_work.id,
+        }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to include('デモアカウント')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #36 に対応します。

### 実装内容

1. **ワークシート名編集モーダル**
   - 共有ヘッダーからワークシート名をクリック
   - EditWorksheetModal コンポーネントを表示
   - ワークシート名を編集して保存

2. **メンバー割り当て変更モーダル**
   - ダッシュボードのメンバーをクリック
   - AssignMemberModal コンポーネントを表示
   - 割り当て先を変更して保存

### テスト状況

- React テスト: 🔄 実装中 (15/15 テストケース作成済み)
  - EditWorksheetModal.test.tsx: 7 テスト
  - AssignMemberModal.test.tsx: 8 テスト
- Rails テスト: 🔄 実装予定
- コンポーネント: 🔄 実装予定